### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.1
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## 0.11.0 - 2020-2-26
 
 * 对网络的断开和重连进行了简单的优化

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: video_box
 description: A control that plays video in flutter, I make the control as flexible as possible, can play a single video, video list on the page.
-version: 0.11.0
+version: 0.11.1
 homepage: https://github.com/januwA/flutter_video_box
 
 environment:
@@ -12,7 +12,7 @@ dependencies:
   video_player: ^0.10.5
   mobx: ^1.0.2
   flutter_mobx: ^1.0.1
-  sensors: ^0.4.1+7
+  sensors: '>=0.4.1+7 <2.0.0'
   connectivity: ^0.4.8+1
 
 dev_dependencies:


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).